### PR TITLE
fix: eslint config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.validate": ["javascript", "typescript"],
   "eslint.experimental.useFlatConfig": true,
+  "eslint.useFlatConfig": true,
   "typescript.tsdk": "./node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "files.exclude": {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,12 @@
 import configLove from 'eslint-config-love'
 
 export default [
-  configLove,
   {
+    ...configLove,
+    files: ["src/**/*.{ts,js}"],
     rules: {
-      'no-console': 'error'
+      ...configLove.rules,
+      'no-console': 'error',
     }
   }
 ]


### PR DESCRIPTION
I have the same problem using `eslint-config-love@48.0.0` , It looks like the new version of  eslint (`eslint@9.0.0 `) changes completely the way is configured now,  first of all in the config file you should specify the files extension and extends the configuration of eslint-config-love using the spread operator:

```JavaScript
import configLove from 'eslint-config-love'

export default [
  {
    ...configLove,
    files: ["src/**/*.{ts,js}"],
    rules: {
      ...configLove.rules,
      'no-console': 'error',
    }
  }
]
```

With this config you must be able to run 
```sh 
npx eslint .
``` 
and get the linter errors in the console (at least it works for me), you can see more about the configuration in the eslint [docs](https://eslint.org/docs/latest/use/configure/).

If you have the vscode Eslint extension you need to configurate the way it works depending of the version of the extension, if you are using the `pre-release@3.0.5` you need to set the rule: 
```json
{
 "eslint.useFlatConfig": true,
}
```
if your Eslint vscode extension version is behind the `pre-release@<3.0.5` you should use the experimental rule:
```json
{
  "eslint.experimental.useFlatConfig": true,
}
```
Check the [docs](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#release-notes) of the extension for more information